### PR TITLE
Remove build scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 auto-top.gypi
 auto.gypi
 build
-bsatk  
+bsatk
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-auto-top.gypi
-auto.gypi
 build
-bsatk  
+bsatk
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "*.ksy": "yaml",
-        "memory": "cpp"
-    }
-}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 node.js bindings for bsatk, a simplistic library for parsing bsa files used in games based on the gamebryo engine.
 
-# TODO
+# Compiling
+
+## Windows
 
 zlib is currently included as compiled artifacts.
+
+## Linux
+
+Libraries must be installed prior to building.
+
+- Arch  
+```sh
+sudo pacman -Syu zlib lz4
+```
+
+- Debian  
+```sh
+sudo apt install zlib1g-dev liblz4-dev
+```
+
+- Fedora  
+```sh
+sudo dnf install zlib-devel lz4-devel
+```

--- a/autogypi.json
+++ b/autogypi.json
@@ -1,5 +1,0 @@
-{
-	"dependencies": [
-	],
-	"includes": []
-}

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,9 +2,6 @@
     "targets": [
         {
             "target_name": "bsatk",
-            "includes": [
-                "auto.gypi"
-            ],
             "sources": [
                 "bsatk/src/bsaarchive.cpp",
                 "bsatk/src/bsaexception.cpp",
@@ -16,14 +13,14 @@
             ],
             "include_dirs": [
                 "<!(node -p \"require('node-addon-api').include_dir\")",
-                "./bsatk/src/common",
-                "./zlib/include"
+                "./bsatk/src"
             ],
             "dependencies": [
               "<!(node -p \"require('node-addon-api').gyp\")"
             ],
             "cflags!": ["-fno-exceptions"],
             "cflags_cc!": ["-fno-exceptions"],
+            "cflags_cc": ["-std=c++17"],
             "conditions": [
                 [
                     'OS=="win"',
@@ -37,6 +34,9 @@
                         "libraries": [
                             "-l../zlib/win32/zlibstatic.lib",
                             "-DelayLoad:node.exe"
+                        ],
+                        "include_dirs": [
+                            "./zlib/include"
                         ],
                         "msvs_settings": {
                             "VCCLCompilerTool": {
@@ -60,8 +60,5 @@
                 ]
             ]
         }
-    ],
-    "includes": [
-        "auto-top.gypi"
     ]
 }

--- a/index.cpp
+++ b/index.cpp
@@ -1,4 +1,4 @@
-#include "bsatk/src/bsaarchive.h"
+#include <bsaarchive.h>
 #include "string_cast.h"
 #include <vector>
 #include <thread>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "submodules": "node fetch_bsatk.js",
     "prebuild": "prebuild.cmd -r napi -t 6 -a x64 --prepack codesign",
     "preinstall": "npm run submodules",
-    "install": "prebuild-install -r napi -t 6 -a x64 || (autogypi && node-gyp rebuild)"
+    "install": "prebuild-install -r napi -t 6 -a x64 || node-gyp rebuild"
   },
   "binary": {
     "napi_versions": [
@@ -23,10 +23,8 @@
     "prebuild": "^11.0.3"
   },
   "dependencies": {
-    "autogypi": "^0.2.2",
-    "node-addon-api": "^4.0.0",
+    "node-addon-api": "^5.0.0",
     "node-gyp": "^9.0.0",
-    "tmp": "0.0.29",
     "prebuild-install": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "submodules": "node fetch_bsatk.js",
     "prebuild": "prebuild.cmd -r napi -t 6 -a x64 --prepack codesign",
     "preinstall": "npm run submodules",
-    "install": "prebuild-install -r napi -t 6 -a x64 || (autogypi && node-gyp rebuild)"
+    "install": "prebuild-install -r napi -t 6 -a x64 || node-gyp rebuild"
   },
   "binary": {
     "napi_versions": [
@@ -24,9 +24,8 @@
   },
   "dependencies": {
     "autogypi": "^0.2.2",
-    "node-addon-api": "^4.0.0",
+    "node-addon-api": "^5.0.0",
     "node-gyp": "^9.0.0",
-    "tmp": "0.0.29",
     "prebuild-install": "^7.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,7 +154,7 @@ asynckit@^0.4.0:
 autogypi@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/autogypi/-/autogypi-0.2.2.tgz#258bab5f7857755b09beac6a641fea130ff4622d"
-  integrity sha1-JYurX3hXdVsJvqxqZB/qEw/0Yi0=
+  integrity sha512-NkDsjbybxo98NEUpvDULvV6w4OxhnX8owBptd8/GlQLhi81TZrh7siRYX9zVEoAYpYaX5QrRuIZAtgYD9PGDXg==
   dependencies:
     bluebird "^3.4.0"
     commander "~2.9.0"
@@ -384,7 +384,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
 commander@2.9.x, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  integrity sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==
   dependencies:
     graceful-readlink ">= 1.0.0"
 
@@ -1255,10 +1255,10 @@ node-abi@^3.0.0, node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
-node-addon-api@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
-  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
 node-gyp@^6.0.1:
   version "6.1.0"
@@ -1447,7 +1447,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -1669,7 +1669,7 @@ request@2, request@^2.54.0, request@^2.88.0:
 resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+  integrity sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==
 
 retry@^0.12.0:
   version "0.12.0"
@@ -1952,13 +1952,6 @@ through2@~0.6.3:
   dependencies:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
-
-tmp@0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
-  integrity sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 tough-cookie@~2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,15 +151,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-autogypi@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/autogypi/-/autogypi-0.2.2.tgz#258bab5f7857755b09beac6a641fea130ff4622d"
-  integrity sha1-JYurX3hXdVsJvqxqZB/qEw/0Yi0=
-  dependencies:
-    bluebird "^3.4.0"
-    commander "~2.9.0"
-    resolve "~1.1.7"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -223,7 +214,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3, bluebird@^3.4.0:
+bluebird@^3:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -381,7 +372,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.x, commander@~2.9.0:
+commander@2.9.x:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
@@ -1255,10 +1246,10 @@ node-abi@^3.0.0, node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
-node-addon-api@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
-  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
 node-gyp@^6.0.1:
   version "6.1.0"
@@ -1447,7 +1438,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -1665,11 +1656,6 @@ request@2, request@^2.54.0, request@^2.88.0:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
-
-resolve@~1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 retry@^0.12.0:
   version "0.12.0"
@@ -1952,13 +1938,6 @@ through2@~0.6.3:
   dependencies:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
-
-tmp@0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
-  integrity sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 tough-cookie@~2.5.0:
   version "2.5.0"


### PR DESCRIPTION
https://docs.npmjs.com/cli/v9/using-npm/scripts#best-practices
And I don't even like node-gyp, but this is clearly better.

@TanninOne zlib is still outdated and should be added as a direct dependency, like bsatk in this PR.
node-gamebryo-savegames could benefit from this method of dependency management as well.
Though, cmake-js would make the most sense, since building zlib requires cmake anyways.